### PR TITLE
Create npm-publish-github-packages.yml

### DIFF
--- a/.github/workflows/npm-publish-github-packages.yml
+++ b/.github/workflows/npm-publish-github-packages.yml
@@ -1,0 +1,36 @@
+# This workflow will run tests using node and then publish a package to GitHub Packages when a release is created
+# For more information see: https://docs.github.com/en/actions/publishing-packages/publishing-nodejs-packages
+
+name: Node.js Package
+
+on:
+  release:
+    types: [created]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - run: npm ci
+      - run: npm test
+
+  publish-gpr:
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          registry-url: https://npm.pkg.github.com/
+      - run: npm ci
+      - run: npm publish
+        env:
+          NODE_AUTH_TOKEN: ${{secrets.GITHUB_TOKEN}}


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow to automate the testing and publishing of Node.js packages to GitHub Packages upon the creation of a release.

### New GitHub Actions Workflow:
* `.github/workflows/npm-publish-github-packages.yml`: Added a workflow named "Node.js Package" that runs tests using Node.js 20 and publishes the package to GitHub Packages when a release is created. It includes two jobs:
  * `build`: Checks out the code, sets up Node.js, installs dependencies, and runs tests.
  * [`publish-gpr`](diffhunk://#diff-8278f114fcdc2cabbbcd45a250368d038f1792dc63f0e49abf52c46cffd57223R1-R36): Publishes the package to GitHub Packages, using the `GITHUB_TOKEN` for authentication.